### PR TITLE
Use relative path for assets folder

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -7,7 +7,7 @@ var t1 = new Date().getTime();
 ion.sound({
   sounds: [{name: "shake"}],
   volume: 0.5,
-  path: "/assets/",
+  path: "assets/",
   preload: true
 });
 


### PR DESCRIPTION
Otherwise github.io version tries to load `https://marcelinollano.github.io/assets/shake.mp3?1465663383255` (instead of `https://marcelinollano.github.io/stupid-maraca/assets/shake.mp3?1465663383255`).

Fun project! :shipit: 
